### PR TITLE
Add Oklab color space reconstruction loss

### DIFF
--- a/src/hakulatent/losses/__init__.py
+++ b/src/hakulatent/losses/__init__.py
@@ -14,12 +14,55 @@ loss_table = {
     "gnll": nn.GaussianNLLLoss,
 }
 
+def srgb_to_oklab(srgb: torch.Tensor) -> torch.Tensor:
+    # Convert to linear RGB space.
+    rgb = torch.where(
+        srgb <= 0.04045,
+        srgb / 12.92,
+        # Clamping avoids NaNs in backwards pass
+        ((torch.clamp(srgb, min=0.04045) + 0.055) / 1.055) ** 2.4
+    )
+
+    # Convert RGB to LMS (cone response)
+    t_rgb_lms = torch.tensor([
+        [0.4122214708, 0.5363325363, 0.0514459929],
+        [0.2119034982, 0.6806995451, 0.1073969566],
+        [0.0883024619, 0.2817188376, 0.6299787005]
+    ], dtype=srgb.dtype, device=srgb.device)
+
+    lin_lms = torch.tensordot(rgb, t_rgb_lms, dims=([1], [0]))
+
+    # Cone response cuts off at low light and we rely on rods, but assume a
+    # linear response in low light to preserve differentiablity.
+    # (2/255) / 12.92, which is roughly in the range of scotopic vision
+    # (2e-6 cd/m^2) given a bright 800x600 CRT at 250 cd/m^2.
+
+    # Apply nonlinearity to LMS
+    X = 6e-4
+    A = (X ** (1/3)) / X
+
+    lms = torch.where(
+        lin_lms <= X,
+        lin_lms * A,
+        # Clamping avoids NaNs in backwards pass
+        torch.clamp(lin_lms, min=X) ** (1/3)
+    )
+
+    # Convert LMS to Oklab
+    t_lms_oklab = torch.tensor([
+        [0.2104542553, 0.7936177850, -0.0040720468],
+        [1.9779984951, -2.4285922050, 0.4505937099],
+        [0.0259040371, 0.7827717662, -0.8086757660]
+    ], dtype=srgb.dtype, device=srgb.device)
+
+    return torch.tensordot(lms, t_lms_oklab, dims=([1], [0]))
 
 class ReconLoss(nn.Module):
     def __init__(
         self,
         loss_type="mse",
         lpips_net="alex",
+        loss_colorspace="srgb",
         convnext_type=None,
         convnext_kwargs={},
         loss_weights={},
@@ -27,6 +70,7 @@ class ReconLoss(nn.Module):
         super(ReconLoss, self).__init__()
         self.loss = loss_table[loss_type]()
         self.loss_weight = loss_weights.get(loss_type, 1.0)
+        self.loss_colorspace = loss_colorspace
         if lpips_net is not None:
             self.lpips_loss = LPIPSLoss(lpips_net)
             self.lpips_weight = loss_weights.get("lpips", 1.0)
@@ -41,6 +85,18 @@ class ReconLoss(nn.Module):
             self.convn_loss = None
 
     def forward(self, x_real, x_recon):
+        # losses relying on trained networks need to stay as sRGB
+        x_real_srgb = x_real
+        x_recon_srgb = x_recon
+
+        if self.loss_colorspace == "srgb":
+            pass # assumed that pixel data is in sRGB space
+        elif self.loss_colorspace == "oklab":
+            x_real = srgb_to_oklab(x_real)
+            x_recon = srgb_to_oklab(x_recon)
+        else:
+            raise NotImplementedError
+
         if isinstance(self.loss, nn.GaussianNLLLoss):
             x_recon, var = torch.split(
                 x_recon, (x_real.size(1), x_recon.size(1) - x_real.size(1)), dim=1
@@ -50,9 +106,9 @@ class ReconLoss(nn.Module):
         else:
             base = self.loss(x_recon, x_real) * self.loss_weight
         if self.lpips_loss is not None:
-            lpips = self.lpips_loss(x_recon, x_real)
+            lpips = self.lpips_loss(x_recon_srgb, x_real_srgb)
             base += lpips * self.lpips_weight
         if self.convn_loss is not None:
-            convn = self.convn_loss(x_recon, x_real)
+            convn = self.convn_loss(x_recon_srgb, x_real_srgb)
             base += convn * self.convn_weight
         return base


### PR DESCRIPTION
Adds the option to score reconstruction loss in the Oklab color space while keeping the model inputs/outputs parameterized as sRGB, similar to what is used in https://github.com/drhead/vae_training_tools. The original code was written by @redhottensors and myself.

The purpose of this code is to score reconstruction loss in a perceptually uniform color space that more accurately reflects how human color perception works.  sRGB is not a good candidate for this: sRGB is designed for your monitor to display colors, and differences in sRGB color values are roughly uniform for individual subpixels on your monitor, but human vision does not operate under those terms. For example, green contributes far more to the lightness of an image than blue, but under sRGB we're treating differences in the blue channel as equally important, even though the same difference in the green channel might be way more noticeable.

Oklab is a perceptually uniform color space.  Under it, Euclidean distances (like L1 or L2 loss) will correspond directly to human perception (so a change of +0.1 will result in roughly the same relative change no matter where the starting point is), which you want if your goal involves humans looking at the images.  This likely will also reduce conflicts with LPIPS, which would most likely have learned to some extent which types of color differences are more perceptible.

This can be used by passing `loss_colorspace="oklab"` when instantiating a `ReconLoss`.  Default behavior is still sRGB.  Losses involving trained models (LPIPS, ConvNext) will still use sRGB, since the model is trained on those losses.

In the future it would also be helpful to set up your dataloader to apply color profiles to whatever images you are loading so that they are the correct colors in sRGB space, rather than another color profile like Adobe RGB being incorrectly handled as sRGB.  Some preprocessed datasets may have had this color profile information lost or removed, but I find that raw data sources like booru imageboards may have around 5% of all images using a different color profile than sRGB.

I am unable to test this at present due to my machine being busy. It should either work as-is, run into a shape mismatch error, or throw NaNs.